### PR TITLE
Avoid deprecated function and allow more than 100 sites

### DIFF
--- a/wp-cron.py
+++ b/wp-cron.py
@@ -39,8 +39,8 @@ s = subprocess.check_output([WP_CLI_PATH, '--path=%s' % WP_DIR, '--skip-themes',
 	if ( ! is_multisite() ) {
 		$urls[] = home_url();
 	} else {
-		foreach ( wp_get_sites() as $blog ) {
-			$urls[] = get_home_url( $blog['blog_id'] );
+		foreach ( get_sites(array('number' => 0)) as $blog ) {
+			$urls[] = get_home_url( $blog->blog_id );
 		}
 	}
 


### PR DESCRIPTION
Hi the code uses  wp_get_sites() and is deprecated, also won't work with large multisite instance (more than 100 sites)

Best regards and thanks for sharing!